### PR TITLE
feat: add error state for deleted shared estimates

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1468,6 +1468,60 @@ body.share-view-mode .header {
     font-weight: 500;
 }
 
+/* Share Error State */
+.share-error-state {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 60vh;
+    padding: var(--spacing-2xl);
+}
+
+.share-error-content {
+    text-align: center;
+    max-width: 500px;
+    margin: 0 auto;
+    width: 100%;
+}
+
+.share-error-icon {
+    width: 60px;
+    height: 60px;
+    color: var(--color-secondary);
+    margin: 0 auto var(--spacing-xl) auto;
+    opacity: 0.9;
+}
+
+.share-error-title {
+    font-family: var(--font-heading);
+    font-size: 2rem;
+    font-weight: 700;
+    color: var(--color-text);
+    margin: 0 0 var(--spacing-lg) 0;
+}
+
+.share-error-message {
+    font-size: 1.125rem;
+    color: var(--color-text);
+    margin: 0 0 var(--spacing-md) 0;
+    line-height: 1.6;
+}
+
+.share-error-suggestion {
+    font-size: 1rem;
+    color: var(--color-text-secondary);
+    margin: 0 0 var(--spacing-2xl) 0;
+    line-height: 1.6;
+}
+
+.share-error-content .btn-primary {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: var(--spacing-sm) var(--spacing-lg);
+    font-size: 1rem;
+}
+
 .share-header {
     text-align: center;
     margin-bottom: var(--spacing-2xl);

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -2395,6 +2395,44 @@ function copyShareLink() {
         });
 }
 
+// Show error state when shared estimate cannot be loaded
+function showShareErrorState() {
+    // Hide the main heading
+    const mainHeading = document.getElementById('mainHeading');
+    if (mainHeading) mainHeading.style.display = 'none';
+
+    // Hide normal view, show share view
+    const normalView = document.getElementById('normalView');
+    const shareView = document.getElementById('shareView');
+    if (normalView) normalView.style.display = 'none';
+    if (shareView) shareView.style.display = 'block';
+
+    // Hide share content, show error state
+    const shareHeader = document.querySelector('.share-view-header');
+    const estimateDisplay = document.getElementById('shareEstimateDisplay');
+    const shareActions = document.querySelector('.share-actions');
+    const shareFooter = document.querySelector('.share-footer-link');
+    const errorState = document.getElementById('shareErrorState');
+
+    if (shareHeader) shareHeader.style.display = 'none';
+    if (estimateDisplay) estimateDisplay.style.display = 'none';
+    if (shareActions) shareActions.style.display = 'none';
+    if (shareFooter) shareFooter.style.display = 'none';
+    if (errorState) errorState.style.display = 'block';
+
+    // Remove loading class to stop the spinner
+    document.body.classList.remove('initial-load');
+
+    // Set up the "Create Your Own Estimate" button
+    const createButton = document.getElementById('createOwnEstimateButton');
+    if (createButton) {
+        createButton.addEventListener('click', () => {
+            // Redirect to home page (normal calculator view)
+            window.location.href = window.location.pathname;
+        });
+    }
+}
+
 // Check for shared estimate on page load
 async function checkForSharedEstimate() {
     const urlParams = new URLSearchParams(window.location.search);
@@ -2406,7 +2444,7 @@ async function checkForSharedEstimate() {
     const { data, error } = await loadSharedEstimate(shareToken);
 
     if (error) {
-        showToast('Failed to load shared estimate: ' + error.message, 'error');
+        showShareErrorState();
         return;
     }
 

--- a/index.html
+++ b/index.html
@@ -85,6 +85,24 @@
 
         <!-- Share View: Read-Only Presentation (hidden by default) -->
         <div id="shareView" class="share-view" style="display: none;">
+            <!-- Error State (shown when estimate not found) -->
+            <div id="shareErrorState" class="share-error-state" style="display: none;">
+                <div class="share-error-content">
+                    <svg class="share-error-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="currentColor">
+                        <path d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7 .2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8 .2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24V296c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224a32 32 0 1 0 -64 0 32 32 0 1 0 64 0z"/>
+                    </svg>
+                    <h2 class="share-error-title">Estimate Not Found</h2>
+                    <p class="share-error-message">This estimate is no longer available. It may have been deleted by the person who shared it with you.</p>
+                    <p class="share-error-suggestion">If you need access to this estimate, please contact the person who shared the link and ask them to send an updated version.</p>
+                    <button class="btn-primary btn-large" id="createOwnEstimateButton">
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" width="16" height="16" fill="currentColor" style="margin-right: 8px;">
+                            <path d="M256 80c0-17.7-14.3-32-32-32s-32 14.3-32 32V224H48c-17.7 0-32 14.3-32 32s14.3 32 32 32H192V432c0 17.7 14.3 32 32 32s32-14.3 32-32V288H400c17.7 0 32-14.3 32-32s-14.3-32-32-32H256V80z"/>
+                        </svg>
+                        Create Your Own Estimate
+                    </button>
+                </div>
+            </div>
+
             <!-- Header with metadata -->
             <div class="share-view-header">
                 <h1 class="share-view-title">Trip Cost Estimate</h1>


### PR DESCRIPTION
- Add "Estimate Not Found" error page shown when accessing deleted share links
- Display user-friendly message with warning icon and clear explanation
- Include "Create Your Own Estimate" button to guide users to calculator
- Replace infinite loading spinner with proper error handling
- Style error state with centered content, secondary color icon, and responsive design

Fixes issue where users attempting to access a deleted estimate would see an infinite loading spinner. Now shows a helpful error message with guidance on next steps.