### PR TITLE
feat: add empty state for authenticated users and improve estimate wo…

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1591,6 +1591,43 @@ body.sign-in-view-mode .header-menu {
 }
 
 /* ===========================
+   Empty State
+   =========================== */
+.empty-state-container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 60vh;
+    padding: var(--spacing-2xl);
+}
+
+.empty-state-content {
+    text-align: center;
+    max-width: 500px;
+}
+
+.empty-state-content h2 {
+    font-size: 2rem;
+    margin-bottom: var(--spacing-md);
+    color: var(--color-text);
+    font-weight: 600;
+}
+
+.empty-state-content p {
+    font-size: 1.1rem;
+    color: var(--color-text-secondary);
+    margin-bottom: var(--spacing-2xl);
+    line-height: 1.6;
+}
+
+.empty-state-actions {
+    display: flex;
+    gap: var(--spacing-md);
+    justify-content: center;
+    flex-wrap: wrap;
+}
+
+/* ===========================
    Share View
    =========================== */
 /* Share View Container */

--- a/index.html
+++ b/index.html
@@ -90,6 +90,21 @@
             </button>
         </div>
 
+        <!-- Empty State (shown for authenticated users with no estimate loaded) -->
+        <div id="emptyState" class="empty-state-container" style="display: none;">
+            <div class="empty-state-content">
+                <h2>Ready to create a trip estimate?</h2>
+                <p>Start a new estimate or load one you've saved.</p>
+                <div class="empty-state-actions">
+                    <button class="btn-primary" id="emptyStateNewEstimate">Create New Estimate</button>
+                    <button class="btn-secondary" id="emptyStateMyEstimates">My Estimates</button>
+                </div>
+            </div>
+        </div>
+
+        <!-- Calculator Form Container -->
+        <div id="calculatorForm" style="display: block;">
+
         <!-- Sign-In View (shown by default for unauthenticated users) -->
         <div id="signInView" class="sign-in-view" style="display: none;">
             <div class="sign-in-container">
@@ -121,6 +136,8 @@
                 <p class="sign-in-subtitle">Sign in to save estimates and create custom profiles</p>
             </div>
         </div>
+
+        </div> <!-- End Calculator Form Container -->
 
         <!-- Share View: Read-Only Presentation (hidden by default) -->
         <div id="shareView" class="share-view" style="display: none;">
@@ -444,7 +461,11 @@
             <div class="estimates-header">
                 <button class="btn-back" id="backFromEstimates">&larr; Back</button>
                 <h1>My Estimates</h1>
-                <div style="width: 48px;"></div> <!-- Spacer for alignment -->
+                <button class="btn-icon btn-add-estimate-header" id="addEstimateHeaderButton" title="New Estimate">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" width="20" height="20" fill="currentColor">
+                        <path d="M256 80c0-17.7-14.3-32-32-32s-32 14.3-32 32V224H48c-17.7 0-32 14.3-32 32s14.3 32 32 32H192V432c0 17.7 14.3 32 32 32s32-14.3 32-32V288H400c17.7 0 32-14.3 32-32s-14.3-32-32-32H256V80z"/>
+                    </svg>
+                </button>
             </div>
 
             <div class="estimates-list" id="estimatesList">


### PR DESCRIPTION
…rkflow

Add a new empty state screen for authenticated users that displays when no estimate is loaded. This improves the UX by clearly distinguishing between "no estimate loaded" and "working on an estimate" states.

Features added:
- Empty state screen with "Create New Estimate" and "My Estimates" buttons
- New estimates display "Untitled" heading until saved
- '+' button in Estimates view header to create new estimates
- Save modal pre-fills "Untitled" for easy renaming

UX improvements:
- Skip warning modal when creating new estimate if no unsaved changes
- Only show warning when there's actual risk of data loss
- Consistent state restoration when navigating between views

Bug fixes:
- Fix change tracking to work for new unsaved estimates
- Fix empty state visibility when returning from "My Estimates" view
- Fix "Discard Changes" to work correctly for new estimates
- Fix save button indicator badge not clearing after successful save
- Fix initial leg only added when needed (not for empty state)

Technical changes:
- Update markAsChanged() to track changes for all estimates
- Add showEmptyState()/hideEmptyState() helper functions
- Update closeEstimatesView() to restore proper state
- Conditionally add initial leg based on user authentication and estimate state
- Update save/update functions to clear visual indicators

This creates a clearer mental model for authenticated users: they're either viewing the empty state, working on a new "Untitled" estimate, or editing a saved estimate. Guest users are unaffected and still get immediate calculator access.